### PR TITLE
not displaying custom fields on about page

### DIFF
--- a/oarepo_communities/ui/communities_components/templates/oarepo/invenio_communities/details/about/index.html
+++ b/oarepo_communities/ui/communities_components/templates/oarepo/invenio_communities/details/about/index.html
@@ -24,9 +24,9 @@
             {% if funding.award %}
               <dd class="header">
                 {{ funding.award.title_l10n }}
-                <label class="ui basic small label">
+                <span class="ui basic small label">
                   {{funding.award.number}}
-                </label>
+                </span>
 
                 {% if funding.award.identifiers|length and funding.award.identifiers[0].scheme == "url" %}
                   <a

--- a/oarepo_communities/ui/communities_components/templates/oarepo/invenio_communities/details/about/index.html
+++ b/oarepo_communities/ui/communities_components/templates/oarepo/invenio_communities/details/about/index.html
@@ -1,0 +1,54 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/details/base.html" %}
+{% from "invenio_communities/details/macros/custom_fields.html" import list_vocabulary_values, list_string_values, show_custom_field %}
+{% set active_community_header_menu_item= 'about' %}
+
+{%- block page_body %}
+  {{ super() }}
+  <div class="ui text container rel-m-2 rel-pt-1">
+    {{ community.metadata.page | safe }}
+    {% if community.ui.funding|length %}
+      <h3 class="ui header">{{ _("Awards") }}</h3>
+      <dl class="ui list">
+
+        {% for funding in community.ui.funding %}
+          <div class="item rel-mb-1">
+            {% if funding.award %}
+              <dd class="header">
+                {{ funding.award.title_l10n }}
+                <label class="ui basic small label">
+                  {{funding.award.number}}
+                </label>
+
+                {% if funding.award.identifiers|length and funding.award.identifiers[0].scheme == "url" %}
+                  <a
+                    class="ui transparent icon button"
+                    href="{{ funding.award.identifiers[0].identifier }}"
+                    aria-label="{{ _('Visit external website') }}"
+                    title="{{ _('Opens in new tab') }}"
+                  >
+                    <i class="external primary icon" aria-hidden="true"></i>
+                  </a>
+                {% endif %}
+              </dd>
+            {% endif %}
+
+            {% if funding.funder %}
+              <dt class="text-muted">
+                {{ funding.funder.name }}
+              </dt>
+            {% endif %}
+          </div>
+        {% endfor %}
+
+      </dl>
+    {% endif %}
+{%- endblock page_body -%}


### PR DESCRIPTION
We are using custom fields for community configuration, therefore they shall not be displayed on publicly available about page. 