### PR TITLE
moved cCustomHTTP error to oarepo requests

### DIFF
--- a/oarepo_communities/errors.py
+++ b/oarepo_communities/errors.py
@@ -9,51 +9,13 @@
 
 from __future__ import annotations
 
-import json
-from typing import Any, Optional, Union
 
-from flask import g
 from flask_resources import (
-    HTTPJSONException,
     create_error_handler,
 )
-from flask_resources.serializers.json import JSONEncoder
 from marshmallow import ValidationError
 from oarepo_runtime.i18n import lazy_gettext as _
-
-
-class CustomHTTPJSONException(HTTPJSONException):
-    """Custom HTTP Exception delivering JSON error responses with an error_type."""
-
-    def __init__(
-        self,
-        code: Optional[int] = None,
-        errors: Optional[Union[dict[str, any], list]] = None,
-        error_type: Optional[str] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Initialize CustomHTTPJSONException."""
-        super().__init__(code=code, errors=errors, **kwargs)
-        self.error_type = error_type  # Save the error_type passed in the constructor
-
-    def get_body(self, environ: any = None, scope: any = None) -> str:
-        """Get the request body."""
-        body = {"status": self.code, "message": self.get_description(environ)}
-
-        errors = self.get_errors()
-        if errors:
-            body["errors"] = errors
-
-        # Add error_type to the response body
-        if self.error_type:
-            body["error_type"] = self.error_type
-
-        # TODO: Revisit how to integrate error monitoring services. See issue #56
-        # Temporarily kept for expediency and backward-compatibility
-        if self.code and (self.code >= 500) and hasattr(g, "sentry_event_id"):
-            body["error_id"] = str(g.sentry_event_id)
-
-        return json.dumps(body, cls=JSONEncoder)
+from oarepo_requests.errors import CustomHTTPJSONException
 
 
 class CommunityAlreadyIncludedException(Exception):
@@ -92,6 +54,7 @@ class MissingCommunitiesError(ValidationError):
     """"""
 
     description = _("Communities are not present in the input.")
+
 
 class CommunityDoesntExistError(ValidationError):
     """"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-communities
-version = 5.3.1
+version = 5.3.2
 description =
 authors = Ronald Krist <krist@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
Moved customHTTP error to oarepo-requests, as oarepo-communities depends on oarepo-requests and it is needed in oarepo-requests too. Should it better be in oarepo ui?

Related PR https://github.com/oarepo/oarepo-requests/pull/142