### PR TITLE
Remove invenio_app_rdm_communities blueprint entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ oarepo_communities_records_ui_theme = "oarepo_communities.ui.oarepo_communities.
 oarepo_communities = "oarepo_communities.ext:OARepoCommunities"
 
 [project.entry-points."invenio_base.blueprints"]
-invenio_app_rdm_communities = "invenio_app_rdm.communities_ui.views:create_ui_blueprint"
+# invenio_app_rdm_communities is now registered directly via invenio_app_rdm
 oarepo_communities_ui = "oarepo_communities.ui.oarepo_communities:create_blueprint"
 
 [project.entry-points."invenio_base.api_finalize_app"]


### PR DESCRIPTION
## Summary
- Removes the `invenio_app_rdm_communities` entry point from `pyproject.toml`
- This blueprint is now registered directly via `invenio_app_rdm` itself, so registering it here is no longer necessary

## Test plan
- [ ] Verify that community UI routes still work correctly after this change
- [ ] Confirm `invenio_app_rdm` is registering the blueprint on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)