### PR TITLE
Major bump due to changes in invenio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
 [project]
 name = "oarepo-communities"
-version = "8.1.4"
+version = "9.0.0"
 description = ""
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14,<3.15"
 dependencies = [
-    "oarepo-requests>=5.0.0,<6.0.0",
+    "oarepo-requests>=7.0.0,<8.0.0",
     "oarepo[rdm,tests]>=14.0.0dev0,<15.0.0",
-    "oarepo-runtime>=4.0.0,<5.0.0",
-    "oarepo-workflows>=4.0.0,<5.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
+    "oarepo-workflows>=5.0.0,<6.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b10.dev5,<15.0.0",
-    "invenio-rdm-records>=28.2.0,<29.0.0",
+    "invenio-rdm-records>=29.0.0,<30.0.0",
     "invenio-search>=3.1.2,<4.0.0",
 ]
 
@@ -28,8 +28,8 @@ dev = [
 ]
 tests = [
     "pytest-invenio>=4.0.0,<5.0.0",
-    "pytest-oarepo>=3.0.0,<4.0.0",
-    "oarepo-rdm>=3.0.0,<4.0.0",
+    "pytest-oarepo>=5.0.0,<6.0.0",
+    "oarepo-rdm>=6.0.0,<7.0.0",
 ]
 
 oarepo14 = [


### PR DESCRIPTION
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-runtime, pytest-oarepo, oarepo-rdm, oarepo-workflows, oarepo-requests.

## Included pull requests

- fixed communities cli ([#158](https://github.com/oarepo/oarepo-communities/pull/158))
