### PR TITLE
fix: communities in user api

### DIFF
--- a/oarepo_communities/ext.py
+++ b/oarepo_communities/ext.py
@@ -145,3 +145,17 @@ def finalize_app(app: Flask) -> None:
 
     requests = app.extensions["invenio-requests"]
     requests.entity_resolvers_registry.register_type(CommunityRoleResolver())
+
+    # replace SharedOrMyRequestsParam with CommunitiesSharedOrMyRequestsParam
+    from invenio_requests.services.requests.config import SharedOrMyRequestsParam, UserRequestSearchOptions
+
+    from oarepo_communities.services.params import CommunitiesSharedOrMyRequestsParam
+
+    param_interpreter_classes = [
+        param for param in UserRequestSearchOptions.params_interpreters_cls if param != SharedOrMyRequestsParam
+    ]
+
+    if not any(isinstance(param, CommunitiesSharedOrMyRequestsParam) for param in param_interpreter_classes):
+        param_interpreter_classes.append(CommunitiesSharedOrMyRequestsParam)
+
+    UserRequestSearchOptions.params_interpreters_cls = tuple(param_interpreter_classes)

--- a/oarepo_communities/services/params.py
+++ b/oarepo_communities/services/params.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-communities (see https://github.com/oarepo/oarepo-communities).
+#
+# oarepo-communities is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Parameter for shared or my requests in communities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+from invenio_communities.members.records.models import MemberModel
+from invenio_db import db
+from invenio_requests.services.requests.config import SharedOrMyRequestsParam
+from opensearch_dsl.query import Bool, Q
+
+if TYPE_CHECKING:
+    from flask_principal import Identity
+
+
+class CommunitiesSharedOrMyRequestsParam(SharedOrMyRequestsParam):
+    """Param interpreter that includes community roles in /api/users/requests API."""
+
+    @override
+    def _generate_my_requests_query(self, identity: Identity) -> Bool:
+        ret = super()._generate_my_requests_query(identity)
+
+        # check community roles of the given identity
+        community_ids = db.session.query(MemberModel.community_id).filter(MemberModel.user_id == identity.id).all()
+        community_ids = [cid[0] for cid in community_ids]
+
+        # this is just a filter, we can return a broader query that gets narrowed down in other filters
+        return Bool(
+            should=[
+                ret,
+                Q("terms", **{"receiver.community": community_ids}),
+            ],
+        )

--- a/tests/test_communities/test_community_requests.py
+++ b/tests/test_communities/test_community_requests.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from invenio_requests import current_requests_service
 from pytest_oarepo.requests.functions import get_request_type
 
 from oarepo_communities.errors import CommunityAlreadyIncludedError
@@ -86,7 +87,11 @@ def test_community_publish(
 
     record = draft_with_community_factory(community_reader.identity, str(community.id))
     record_id = record["id"]
-    submit_request_on_draft(community_reader.identity, record_id, "publish_draft")
+    submitted_request = submit_request_on_draft(community_reader.identity, record_id, "publish_draft")
+    requests = current_requests_service.search_user_requests(community_reader.identity)
+    request_ids = [request["id"] for request in requests.hits]
+    assert submitted_request["id"] in request_ids
+
     accept_request(
         reader_client,
         type_="publish_draft",


### PR DESCRIPTION
The current API does not return requests from `/api/user/requests` when the user is a recipient of a community action. This is probably caused by our custom community roles.

This PR modifies the original parameter interpreter class so that it adds community recipients for all communities the user belongs to. In practice, for community submission requests, the parameter interpreter pre-matches all requests where `recipient == community` and the user is a member of that community.

This does not introduce any security risk. The other parameter interpreters still filter the matched requests down to the concrete user roles through the `grants` field.
